### PR TITLE
Integrate Cesium 3D viewer

### DIFF
--- a/UAVLogViewer/src/components/Globals.js
+++ b/UAVLogViewer/src/components/Globals.js
@@ -64,5 +64,26 @@ export const store = {
     commit: _COMMIT_.slice(0, 6),
     /* global _BUILDDATE_ */
     buildDate: _BUILDDATE_,
-    childPlots: []
+    childPlots: [],
+    externalDataInjected: false
+}
+
+function mergeExternalState (external) {
+    if (!external || typeof external !== 'object') {
+        return
+    }
+
+    for (const [key, value] of Object.entries(external)) {
+        store[key] = value
+    }
+
+    store.externalDataInjected = true
+}
+
+if (typeof window !== 'undefined') {
+    if (window.__UAVLOGVIEWER_PRELOADED_STATE__) {
+        mergeExternalState(window.__UAVLOGVIEWER_PRELOADED_STATE__)
+    }
+
+    window.__applyUavLogViewerState__ = mergeExternalState
 }


### PR DESCRIPTION
## Summary
- add a Cesium toggle to the PyQt main window and stream DataFrame telemetry to the 3D viewer
- enable the UAVLogViewer store and components to bootstrap from externally provided state
- expose a global Cesium time setter so the desktop timeline can drive the web viewer

## Testing
- python3 -m compileall src
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e952bfb083289de45eb598afad78)