### PR TITLE
feat: add advanced pdf reporting pipeline

### DIFF
--- a/src/utils/pdf_reporter.py
+++ b/src/utils/pdf_reporter.py
@@ -1,89 +1,265 @@
-import io
+import textwrap
 from datetime import datetime
-from PyQt6.QtCore import QObject, pyqtSignal
-from PyQt6.QtGui import QPixmap
+from typing import Any, Dict, Iterable, List
 
-from reportlab.pdfgen import canvas
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, landscape
 from reportlab.lib.units import inch
 from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
+
 
 class PdfReportWorker(QObject):
-    """
-    Gera o relatório PDF em uma thread separada para não congelar a UI.
-    Recebe os dados e as imagens já capturadas da thread principal.
-    """
-    finished = pyqtSignal(str) # Emite o caminho do arquivo salvo ao terminar
-    error = pyqtSignal(str)    # Emite mensagem de erro
+    """Gera o relatório PDF rico em análises e imagens."""
 
-    def __init__(self, file_path, log_name, plot_images, map_images):
+    finished = pyqtSignal(str)
+    error = pyqtSignal(str)
+
+    def __init__(
+        self,
+        *,
+        file_path: str,
+        metadata: Dict[str, Any],
+        plot_sections: Iterable,
+        map_sections: Iterable,
+        analytics: Dict[str, Any],
+    ) -> None:
         super().__init__()
         self.file_path = file_path
-        self.log_name = log_name
-        self.plot_images = plot_images  # Lista de buffers de imagem (BytesIO)
-        self.map_images = map_images    # Lista de buffers de imagem (BytesIO)
+        self.metadata = metadata
+        self.plot_sections = list(plot_sections)
+        self.map_sections = list(map_sections)
+        self.analytics = analytics
 
-    def run(self):
-        """
-        Executa a geração do PDF. Esta função não deve ter nenhuma interação com a UI.
-        """
+    def run(self) -> None:
         try:
-            c = canvas.Canvas(self.file_path, pagesize=landscape(A4))
+            pdf = canvas.Canvas(self.file_path, pagesize=landscape(A4))
             width, height = landscape(A4)
 
-            # --- Página de Título ---
-            self._create_title_page(c, width, height)
+            sections = [
+                "Resumo executivo",
+                "Indicadores de integridade e falhas",
+                "Diagnóstico detalhado por log",
+            ]
+            if self.plot_sections:
+                sections.append("Painel visual - gráficos padrão e completos")
+            if self.map_sections:
+                sections.append("Mapas, vento e trajetória consolidada")
 
-            # --- Páginas de Gráficos ---
-            for img_buffer in self.plot_images:
-                self._add_image_page(c, width, height, img_buffer)
-            
-            # --- Páginas do Mapa ---
-            for i, img_buffer in enumerate(self.map_images):
-                zoom_level = [17, 15, 12][i] # Assumindo 3 níveis de zoom
-                title = f"Trajetória do Voo - Zoom: {zoom_level}"
-                self._add_image_page(c, width, height, img_buffer, title)
+            self._create_title_page(pdf, width, height)
+            self._create_table_of_contents(pdf, width, height, sections)
+            self._create_summary_page(pdf, width, height)
+            self._create_faults_page(pdf, width, height)
+            self._create_per_log_pages(pdf, width, height)
+            self._add_image_collection(pdf, width, height, self.plot_sections, "Painel visual")
+            self._add_image_collection(pdf, width, height, self.map_sections, "Mapas e trajetórias")
 
-            c.save()
+            pdf.save()
             self.finished.emit(self.file_path)
+        except Exception as exc:  # pragma: no cover - protegido por UI
+            self.error.emit(f"Ocorreu um erro ao gerar o PDF: {exc}")
 
-        except Exception as e:
-            self.error.emit(f"Ocorreu um erro ao gerar o PDF: {e}")
+    # ------------------------------------------------------------------
+    # Páginas de texto
+    # ------------------------------------------------------------------
+    def _create_title_page(self, pdf, width, height) -> None:
+        pdf.setFillColor(colors.HexColor("#0f172a"))
+        pdf.rect(0, 0, width, height, stroke=0, fill=1)
+        pdf.setFillColor(colors.white)
+        pdf.setFont("Helvetica-Bold", 32)
+        pdf.drawCentredString(width / 2, height - 2.0 * inch, "Relatório Analítico de Aeronave")
+        pdf.setFont("Helvetica", 16)
+        pdf.drawCentredString(
+            width / 2,
+            height - 2.8 * inch,
+            f"Log ativo: {self.metadata.get('active_log', 'N/D')} | Total de logs: {self.metadata.get('log_count', 0)}",
+        )
+        pdf.setFont("Helvetica", 12)
+        pdf.drawCentredString(
+            width / 2,
+            inch,
+            f"Gerado em {datetime.now().strftime('%d/%m/%Y %H:%M:%S')}",
+        )
+        pdf.showPage()
 
-    def _create_title_page(self, c, width, height):
-        c.setFont("Helvetica-Bold", 24)
-        c.drawCentredString(width / 2, height - 2 * inch, "Relatório de Voo Detalhado")
-        c.setFont("Helvetica", 14)
-        c.drawCentredString(width / 2, height - 2.5 * inch, f"Arquivo de Log: {self.log_name}")
-        c.setFont("Helvetica-Oblique", 12)
-        c.drawCentredString(width / 2, 1 * inch, f"Gerado em: {datetime.now().strftime('%d/%m/%Y %H:%M:%S')}")
-        c.showPage()
+    def _create_table_of_contents(self, pdf, width, height, sections: List[str]) -> None:
+        pdf.setFont("Helvetica-Bold", 24)
+        pdf.drawString(inch, height - inch, "Índice")
+        pdf.setFont("Helvetica", 13)
+        y = height - 1.5 * inch
+        for idx, section in enumerate(sections, start=1):
+            pdf.drawString(inch, y, f"{idx}. {section}")
+            y -= 0.4 * inch
+        pdf.showPage()
 
-    def _add_image_page(self, c, width, height, img_buffer, title=None):
-        img_buffer.seek(0)
-        image_reader = ImageReader(img_buffer)
-        
-        if title:
-            c.setFont("Helvetica-Bold", 16)
-            c.drawCentredString(width / 2, height - 1 * inch, title)
-            margin_top = 1.5 * inch
+    def _create_summary_page(self, pdf, width, height) -> None:
+        summary = self.analytics.get("fleet_summary", {})
+        pdf.setFont("Helvetica-Bold", 22)
+        pdf.drawString(inch, height - inch, "Resumo executivo")
+        pdf.setFont("Helvetica", 12)
+        y = height - 1.7 * inch
+        paragraphs = [
+            f"Logs analisados: {summary.get('total_logs', 0)}",
+            f"Horas totais de voo: {summary.get('total_hours', 0):.2f} h",
+            f"Distância acumulada: {summary.get('total_distance', 0):.1f} km",
+            f"Maior perna individual: {summary.get('max_distance', 0):.1f} km",
+            f"Log em foco (UI): {summary.get('active_log', 'N/D')}",
+        ]
+        for text in paragraphs:
+            y = self._draw_wrapped_text(pdf, text, inch, y, width - 2 * inch, 16)
+        pdf.setFont("Helvetica-Bold", 14)
+        pdf.drawString(inch, y - 0.4 * inch, "Indicadores derivados")
+        derived = [
+            "✓ Energia: monitora tensão mínima e tendência de consumo",
+            "✓ Estrutural: acompanha envelopes de Roll/Pitch/Yaw rate",
+            "✓ Navegação: distância percorrida + erro GNSS vertical",
+            "✓ Meio externo: variabilidade de vento (desvio padrão)",
+        ]
+        y -= inch
+        pdf.setFont("Helvetica", 11)
+        for item in derived:
+            pdf.drawString(inch + 0.2 * inch, y, f"• {item}")
+            y -= 0.3 * inch
+        pdf.showPage()
+
+    def _create_faults_page(self, pdf, width, height) -> None:
+        anomalies = self.analytics.get("global_anomalies", [])
+        pdf.setFont("Helvetica-Bold", 22)
+        pdf.drawString(inch, height - inch, "Indicadores de integridade e falhas")
+        pdf.setFont("Helvetica", 12)
+        y = height - 1.5 * inch
+        if not anomalies:
+            y = self._draw_wrapped_text(
+                pdf,
+                "Nenhum indicador crítico foi encontrado. Continue monitorando tensão, GNSS e envelope aerodinâmico.",
+                inch,
+                y,
+                width - 2 * inch,
+                16,
+            )
         else:
-            margin_top = 1 * inch
+            pdf.setFillColor(colors.HexColor("#fee2e2"))
+            pdf.rect(inch - 0.2 * inch, y - 0.2 * inch, width - 2 * inch + 0.4 * inch, 0.4 * inch + 0.3 * inch * len(anomalies), fill=1, stroke=0)
+            pdf.setFillColor(colors.black)
+            pdf.setFont("Helvetica", 12)
+            y -= 0.1 * inch
+            for item in anomalies:
+                pdf.drawString(inch, y, f"⚠ {item}")
+                y -= 0.3 * inch
+        pdf.showPage()
 
-        img_w, img_h = image_reader.getSize()
-        aspect = img_h / float(img_w)
-        
-        draw_width = width - 2 * inch
-        draw_height = draw_width * aspect
-        
-        # Ajusta se a altura for excessiva
-        max_height = height - margin_top - 1 * inch
-        if draw_height > max_height:
-            draw_height = max_height
-            draw_width = draw_height / aspect
+    def _create_per_log_pages(self, pdf, width, height) -> None:
+        per_log = self.analytics.get("per_log", [])
+        for entry in per_log:
+            pdf.setFont("Helvetica-Bold", 20)
+            pdf.drawString(inch, height - inch, f"Diagnóstico: {getattr(entry, 'name', 'N/D')}")
+            y = height - 1.6 * inch
+            rows = [
+                ("Duração", self._format_duration(getattr(entry, "duration_s", 0))),
+                ("Distância estimada", self._format_float(getattr(entry, "distance_km", None), "km")),
+                ("Altitude", self._format_interval(entry.max_altitude, entry.min_altitude, "m")),
+                ("Roll/Pitch máximo", self._format_pair(entry.max_roll, entry.max_pitch, "°")),
+                ("Taxa de guinada pico", self._format_float(entry.max_yaw_rate, "°/s")),
+                ("Razão vertical pico", self._format_float(entry.vertical_speed_peak, "m/s")),
+                ("Tensão mínima", self._format_float(entry.min_voltage, "V")),
+                ("CHT máximo", self._format_float(entry.max_cht, "°C")),
+                ("Velocidade média (ASI)", self._format_float(entry.avg_asi, "m/s")),
+                ("Variabilidade do vento", self._format_float(entry.wind_std, "σ m/s")),
+                ("Combustível consumido", self._format_float(entry.fuel_used, "unid")),
+                ("Erro GNSS alt", self._format_float(entry.gnss_error, "m")),
+            ]
+            pdf.setFont("Helvetica", 12)
+            for label, value in rows:
+                pdf.drawString(inch, y, f"{label}:")
+                pdf.drawString(inch + 3.3 * inch, y, value)
+                y -= 0.35 * inch
 
-        x = (width - draw_width) / 2
-        y = (height - draw_height - margin_top) / 2 + 1 * inch
-        
-        c.drawImage(image_reader, x, y, width=draw_width, height=draw_height, preserveAspectRatio=True)
-        c.showPage()
+            anomalies = getattr(entry, "anomalies", [])
+            if anomalies:
+                pdf.setFont("Helvetica-Bold", 13)
+                pdf.drawString(inch, y - 0.2 * inch, "Possíveis falhas e recomendações:")
+                pdf.setFont("Helvetica", 12)
+                y -= 0.6 * inch
+                for warning in anomalies:
+                    y = self._draw_wrapped_text(pdf, f"• {warning}", inch + 0.3 * inch, y, width - 2.2 * inch, 14)
+            pdf.showPage()
+
+    # ------------------------------------------------------------------
+    # Páginas de imagem
+    # ------------------------------------------------------------------
+    def _add_image_collection(self, pdf, width, height, sections, group_title: str) -> None:
+        for idx, section in enumerate(sections, start=1):
+            pdf.setFont("Helvetica-Bold", 18)
+            pdf.drawString(
+                inch,
+                height - inch,
+                f"{group_title} – {getattr(section, 'group', '')} ({idx}/{len(sections)})",
+            )
+            pdf.setFont("Helvetica", 11)
+            pdf.drawString(inch, height - 1.4 * inch, getattr(section, "title", ""))
+            self._draw_wrapped_text(pdf, getattr(section, "description", ""), inch, height - 1.8 * inch, width - 2 * inch, 14)
+            img_buffer = getattr(section, "buffer", None)
+            if img_buffer:
+                img_buffer.seek(0)
+                reader = ImageReader(img_buffer)
+                img_w, img_h = reader.getSize()
+                aspect = img_h / float(img_w)
+                draw_width = width - 2 * inch
+                draw_height = draw_width * aspect
+                max_height = height - 3 * inch
+                if draw_height > max_height:
+                    draw_height = max_height
+                    draw_width = draw_height / aspect
+                x = (width - draw_width) / 2
+                y = (height - draw_height) / 2 - 0.5 * inch
+                pdf.drawImage(reader, x, y, draw_width, draw_height, preserveAspectRatio=True)
+            pdf.showPage()
+
+    # ------------------------------------------------------------------
+    # Helpers de formatação
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _draw_wrapped_text(pdf, text: str, x: float, y: float, max_width: float, leading: float) -> float:
+        if not text:
+            return y
+        pdf.setFont("Helvetica", 12)
+        char_width = 0.18 * inch
+        max_chars = max(10, int(max_width / char_width))
+        for line in textwrap.wrap(text, width=max_chars):
+            pdf.drawString(x, y, line)
+            y -= leading
+        return y
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        if not seconds or seconds <= 0:
+            return "N/D"
+        mins, sec = divmod(seconds, 60)
+        hours, mins = divmod(int(mins), 60)
+        return f"{hours:02d}h {mins:02d}min {sec:04.1f}s"
+
+    @staticmethod
+    def _format_float(value, unit: str) -> str:
+        if value is None or (isinstance(value, float) and not value == value):
+            return "N/D"
+        return f"{value:.2f} {unit}"
+
+    @staticmethod
+    def _format_interval(max_value, min_value, unit: str) -> str:
+        if max_value is None and min_value is None:
+            return "N/D"
+        if min_value is None:
+            return f"Até {max_value:.1f} {unit}"
+        if max_value is None:
+            return f"A partir de {min_value:.1f} {unit}"
+        return f"{min_value:.1f} – {max_value:.1f} {unit}"
+
+    @staticmethod
+    def _format_pair(first, second, unit: str) -> str:
+        if first is None and second is None:
+            return "N/D"
+        left = "N/D" if first is None else f"{first:.1f}"
+        right = "N/D" if second is None else f"{second:.1f}"
+        return f"{left}/{right} {unit}"

--- a/src/utils/report_generator.py
+++ b/src/utils/report_generator.py
@@ -1,0 +1,409 @@
+"""Ferramentas de alto nível para gerar relatórios PDF ricos e analíticos."""
+from __future__ import annotations
+
+import io
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+from geopy.distance import geodesic
+from PyQt6.QtCore import QBuffer, QIODevice, QObject, QThread, pyqtSignal
+from PyQt6.QtWidgets import QApplication
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+
+from .pdf_reporter import PdfReportWorker
+
+
+def _safe_title_from_axes(canvas: FigureCanvas) -> str:
+    titles: List[str] = []
+    for ax in canvas.figure.axes:
+        title = ax.get_title()
+        if title:
+            titles.append(title.strip())
+    if not titles and canvas.figure._suptitle is not None:  # type: ignore[attr-defined]
+        titles.append(canvas.figure._suptitle.get_text())  # type: ignore[attr-defined]
+    return "; ".join(titles) if titles else "Captura automática do painel"
+
+
+@dataclass
+class ImageSection:
+    title: str
+    description: str
+    group: str
+    buffer: io.BytesIO
+
+
+@dataclass
+class LogAnalytics:
+    name: str
+    duration_s: float
+    distance_km: float
+    sample_count: int
+    max_altitude: Optional[float]
+    min_altitude: Optional[float]
+    max_roll: Optional[float]
+    max_pitch: Optional[float]
+    max_yaw_rate: Optional[float]
+    vertical_speed_peak: Optional[float]
+    min_voltage: Optional[float]
+    max_cht: Optional[float]
+    avg_asi: Optional[float]
+    wind_std: Optional[float]
+    fuel_used: Optional[float]
+    gnss_error: Optional[float]
+    anomalies: List[str]
+
+
+class ReportGenerationManager(QObject):
+    """Coordena a captura de dados e delega a escrita do PDF para uma thread dedicada."""
+
+    finished = pyqtSignal(str)
+    error = pyqtSignal(str)
+    status = pyqtSignal(str)
+    started = pyqtSignal()
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._thread: Optional[QThread] = None
+        self._worker: Optional[PdfReportWorker] = None
+
+    def generate_pdf(
+        self,
+        *,
+        file_path: str,
+        current_log_name: str,
+        log_data: Dict[str, pd.DataFrame],
+        standard_tab,
+        all_tab,
+        map_widget,
+        map_js_name: str,
+        map_is_ready: bool,
+    ) -> None:
+        if not log_data:
+            self.error.emit("Nenhum log carregado para compor o relatório.")
+            return
+
+        self.status.emit("Capturando imagens dos painéis analíticos...")
+        QApplication.processEvents()
+        plot_sections = self._capture_plot_sections(standard_tab, all_tab)
+
+        self.status.emit("Gerando mosaicos de trajetória e vento...")
+        QApplication.processEvents()
+        map_sections = self._capture_map_sections(map_widget, map_js_name, map_is_ready)
+
+        self.status.emit("Compilando análises estatísticas de todos os logs...")
+        QApplication.processEvents()
+        analytics_payload = self._build_analytics(log_data, current_log_name)
+
+        metadata = {
+            "active_log": current_log_name,
+            "log_count": len(log_data),
+        }
+
+        self._thread = QThread()
+        self._worker = PdfReportWorker(
+            file_path=file_path,
+            metadata=metadata,
+            plot_sections=plot_sections,
+            map_sections=map_sections,
+            analytics=analytics_payload,
+        )
+        self._worker.moveToThread(self._thread)
+
+        self._thread.started.connect(self._worker.run)
+        self._worker.finished.connect(self.finished.emit)
+        self._worker.error.connect(self.error.emit)
+        self._worker.finished.connect(self._thread.quit)
+        self._worker.finished.connect(self._worker.deleteLater)
+        self._thread.finished.connect(self._thread.deleteLater)
+
+        self.started.emit()
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    # Captura de imagens dos painéis
+    # ------------------------------------------------------------------
+    def _capture_plot_sections(self, standard_tab, all_tab) -> List[ImageSection]:
+        sections: List[ImageSection] = []
+        canvases_map = [
+            ("Gráficos padrão", getattr(standard_tab, "findChildren", None)),
+            ("Todos os gráficos", getattr(all_tab, "findChildren", None)),
+        ]
+        for group_name, finder in canvases_map:
+            if finder is None:
+                continue
+            canvases = finder(FigureCanvas)
+            for idx, canvas in enumerate(canvases, start=1):
+                buf = io.BytesIO()
+                canvas.figure.savefig(buf, format="png", dpi=200, bbox_inches="tight", facecolor="white")
+                buf.seek(0)
+                title = f"{group_name} #{idx}"
+                description = _safe_title_from_axes(canvas)
+                sections.append(
+                    ImageSection(
+                        title=title,
+                        description=description,
+                        group=group_name,
+                        buffer=buf,
+                    )
+                )
+        return sections
+
+    def _capture_map_sections(self, map_widget, map_js_name: str, map_is_ready: bool) -> List[ImageSection]:
+        sections: List[ImageSection] = []
+        if not (map_widget and map_js_name and map_is_ready):
+            return sections
+
+        target_zoom = [18, 16, 13]
+        for zoom in target_zoom:
+            map_widget.page().runJavaScript(f"{map_js_name}.setZoom({zoom});")
+            start = time.time()
+            while time.time() - start < 1.5:
+                QApplication.processEvents()
+            pixmap = map_widget.grab()
+            qbuffer = QBuffer()
+            qbuffer.open(QIODevice.OpenModeFlag.ReadWrite)
+            pixmap.save(qbuffer, "PNG")
+            buffer = io.BytesIO(bytes(qbuffer.data()))
+            buffer.seek(0)
+            sections.append(
+                ImageSection(
+                    title=f"Trajetória no mapa - Zoom {zoom}",
+                    description="Plano de voo, vento embarcado e dispersão de pontos em diferentes escalas.",
+                    group="Mapas",
+                    buffer=buffer,
+                )
+            )
+        map_widget.page().runJavaScript(f"{map_js_name}.setZoom(15);")
+        return sections
+
+    # ------------------------------------------------------------------
+    # Análises estatísticas
+    # ------------------------------------------------------------------
+    def _build_analytics(self, log_data: Dict[str, pd.DataFrame], active_log: str):
+        per_log: List[LogAnalytics] = []
+        global_anomalies: List[str] = []
+        durations = []
+        distances = []
+
+        for log_name, df in log_data.items():
+            metrics = self._compute_metrics_for_df(log_name, df)
+            per_log.append(metrics)
+            durations.append(metrics.duration_s)
+            distances.append(metrics.distance_km)
+            global_anomalies.extend(f"{log_name}: {msg}" for msg in metrics.anomalies)
+
+        fleet_summary = {
+            "total_logs": len(per_log),
+            "total_hours": sum(durations) / 3600.0,
+            "total_distance": sum(distances),
+            "active_log": active_log,
+            "max_distance": max(distances) if distances else 0.0,
+        }
+
+        return {
+            "fleet_summary": fleet_summary,
+            "per_log": per_log,
+            "global_anomalies": global_anomalies,
+        }
+
+    def _compute_metrics_for_df(self, log_name: str, df: pd.DataFrame) -> LogAnalytics:
+        if df is None or df.empty:
+            return LogAnalytics(
+                name=log_name,
+                duration_s=0.0,
+                distance_km=0.0,
+                sample_count=0,
+                max_altitude=None,
+                min_altitude=None,
+                max_roll=None,
+                max_pitch=None,
+                max_yaw_rate=None,
+                vertical_speed_peak=None,
+                min_voltage=None,
+                max_cht=None,
+                avg_asi=None,
+                wind_std=None,
+                fuel_used=None,
+                gnss_error=None,
+                anomalies=["Arquivo sem dados válidos."],
+            )
+
+        duration_s = 0.0
+        if "Timestamp" in df.columns and len(df["Timestamp"].dropna()) >= 2:
+            duration_s = (
+                df["Timestamp"].dropna().iloc[-1] - df["Timestamp"].dropna().iloc[0]
+            ).total_seconds()
+
+        distance_km = self._compute_distance(df)
+        max_altitude = self._safe_series_max(df, "AltitudeAbs")
+        min_altitude = self._safe_series_min(df, "AltitudeAbs")
+        max_roll = self._safe_series_absmax(df, "Roll")
+        max_pitch = self._safe_series_absmax(df, "Pitch")
+        max_yaw_rate = self._compute_rate(df, "Yaw")
+        vertical_speed_peak = self._compute_rate(df, "AltitudeAbs")
+        min_voltage = self._safe_series_min(df, "Voltage")
+        max_cht = self._safe_series_max(df, "CHT")
+        avg_asi = self._safe_series_mean(df, "ASI")
+        wind_std = self._safe_series_std(df, "WSI")
+        fuel_used = self._compute_fuel(df)
+        gnss_error = self._safe_series_max(df, "GNSS_AltError")
+
+        anomalies = self._detect_anomalies(
+            max_roll=max_roll,
+            max_pitch=max_pitch,
+            max_yaw_rate=max_yaw_rate,
+            vertical_speed_peak=vertical_speed_peak,
+            min_voltage=min_voltage,
+            max_cht=max_cht,
+            wind_std=wind_std,
+            gnss_error=gnss_error,
+            fuel_used=fuel_used,
+        )
+
+        return LogAnalytics(
+            name=log_name,
+            duration_s=duration_s,
+            distance_km=distance_km,
+            sample_count=len(df),
+            max_altitude=max_altitude,
+            min_altitude=min_altitude,
+            max_roll=max_roll,
+            max_pitch=max_pitch,
+            max_yaw_rate=max_yaw_rate,
+            vertical_speed_peak=vertical_speed_peak,
+            min_voltage=min_voltage,
+            max_cht=max_cht,
+            avg_asi=avg_asi,
+            wind_std=wind_std,
+            fuel_used=fuel_used,
+            gnss_error=gnss_error,
+            anomalies=anomalies,
+        )
+
+    @staticmethod
+    def _compute_distance(df: pd.DataFrame) -> float:
+        if not {"Latitude", "Longitude"}.issubset(df.columns):
+            return 0.0
+        subset = df[["Latitude", "Longitude"]].dropna()
+        if len(subset) < 2:
+            return 0.0
+        coords = list(zip(subset["Latitude"], subset["Longitude"]))
+        total = 0.0
+        for p0, p1 in zip(coords, coords[1:]):
+            try:
+                total += geodesic(p0, p1).kilometers
+            except ValueError:
+                continue
+        return total
+
+    @staticmethod
+    def _compute_rate(df: pd.DataFrame, column: str) -> Optional[float]:
+        if not {column, "Timestamp"}.issubset(df.columns):
+            return None
+        series = df[["Timestamp", column]].dropna()
+        if len(series) < 2:
+            return None
+        values = pd.to_numeric(series[column], errors="coerce").to_numpy()
+        timestamps = pd.to_datetime(series["Timestamp"]).to_numpy()
+        diffs = np.diff(values)
+        dt = np.diff(timestamps.astype("datetime64[ns]").astype(np.int64) / 1e9)
+        dt[dt == 0] = np.nan
+        rates = diffs / dt
+        rates = rates[np.isfinite(rates)]
+        if rates.size == 0:
+            return None
+        return float(np.nanmax(np.abs(rates)))
+
+    @staticmethod
+    def _safe_series_max(df: pd.DataFrame, column: str) -> Optional[float]:
+        if column not in df.columns:
+            return None
+        series = pd.to_numeric(df[column], errors="coerce")
+        if series.dropna().empty:
+            return None
+        return float(series.max())
+
+    @staticmethod
+    def _safe_series_min(df: pd.DataFrame, column: str) -> Optional[float]:
+        if column not in df.columns:
+            return None
+        series = pd.to_numeric(df[column], errors="coerce")
+        if series.dropna().empty:
+            return None
+        return float(series.min())
+
+    @staticmethod
+    def _safe_series_absmax(df: pd.DataFrame, column: str) -> Optional[float]:
+        if column not in df.columns:
+            return None
+        series = pd.to_numeric(df[column], errors="coerce").abs()
+        if series.dropna().empty:
+            return None
+        return float(series.max())
+
+    @staticmethod
+    def _safe_series_mean(df: pd.DataFrame, column: str) -> Optional[float]:
+        if column not in df.columns:
+            return None
+        series = pd.to_numeric(df[column], errors="coerce")
+        if series.dropna().empty:
+            return None
+        return float(series.mean())
+
+    @staticmethod
+    def _safe_series_std(df: pd.DataFrame, column: str) -> Optional[float]:
+        if column not in df.columns:
+            return None
+        series = pd.to_numeric(df[column], errors="coerce")
+        series = series.dropna()
+        if series.empty:
+            return None
+        return float(series.std())
+
+    @staticmethod
+    def _compute_fuel(df: pd.DataFrame) -> Optional[float]:
+        for col in ["FuelLevel_anag", "FuelLevel_dig"]:
+            if col in df.columns:
+                series = pd.to_numeric(df[col], errors="coerce").dropna()
+                if series.empty:
+                    continue
+                return float(series.iloc[0] - series.iloc[-1])
+        return None
+
+    @staticmethod
+    def _detect_anomalies(
+        *,
+        max_roll: Optional[float],
+        max_pitch: Optional[float],
+        max_yaw_rate: Optional[float],
+        vertical_speed_peak: Optional[float],
+        min_voltage: Optional[float],
+        max_cht: Optional[float],
+        wind_std: Optional[float],
+        gnss_error: Optional[float],
+        fuel_used: Optional[float],
+    ) -> List[str]:
+        anomalies: List[str] = []
+        if max_roll is not None and max_roll > 60:
+            anomalies.append(f"Bancos elevados ({max_roll:.1f}°)")
+        if max_pitch is not None and max_pitch > 30:
+            anomalies.append(f"Ângulo de arfagem agressivo ({max_pitch:.1f}°)")
+        if max_yaw_rate is not None and max_yaw_rate > 45:
+            anomalies.append(f"Taxa de guinada acima do nominal ({max_yaw_rate:.1f}°/s)")
+        if vertical_speed_peak is not None and vertical_speed_peak > 8:
+            anomalies.append(f"Razão de subida/descida crítica ({vertical_speed_peak:.1f} m/s)")
+        if min_voltage is not None and min_voltage < 21:
+            anomalies.append(f"Tensão mínima perigosa ({min_voltage:.1f} V)")
+        if max_cht is not None and max_cht > 180:
+            anomalies.append(f"CHT elevado ({max_cht:.1f} °C)")
+        if wind_std is not None and wind_std > 5:
+            anomalies.append(f"Variabilidade de vento alta (σ={wind_std:.1f} m/s)")
+        if gnss_error is not None and gnss_error > 5:
+            anomalies.append(f"Erro GNSS vertical acima do limite ({gnss_error:.1f} m)")
+        if fuel_used is not None and fuel_used < 0:
+            anomalies.append("Sensor de combustível invertido")
+        return anomalies
+*** End of File


### PR DESCRIPTION
## Summary
- move the PDF report orchestration out of `main_window` and into a dedicated `ReportGenerationManager`, which captures plots, maps and computes analytics for every loaded log
- expand the report worker to build a multi-section document with title, index, fleet summary, fault indicators, per-log diagnostics and captioned images that combine standard/all plots plus map zooms
- add heuristics that estimate distance, energy, structural envelopes and GNSS quality for each log to highlight potential aircraft faults in the generated PDF

## Testing
- `python -m compileall src`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbcdee82483289fbca74608b731af)